### PR TITLE
feat: Make rake test the default task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,10 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.pattern = "test/*_test.rb"
+end
+
+desc "Run tests"
+task :default => :test


### PR DESCRIPTION
Now you just have to do `rake` to run the tests. Also, now tests will
always be ran, no matter the default test file pattern in rake.
