### PR TITLE
feat: Initialize with range or array

### DIFF
--- a/lib/exponential_backoff.rb
+++ b/lib/exponential_backoff.rb
@@ -4,9 +4,14 @@ class ExponentialBackoff
   attr_accessor :multiplier, :randomize_factor
   attr_reader   :current_interval
 
-  def initialize(minimal_interval, maximum_elapsed_time)
-    @maximum_elapsed_time = maximum_elapsed_time
-    @minimal_interval = minimal_interval
+  def initialize(interval, maximum_elapsed_time = nil)
+    if interval.respond_to?(:first)
+      @minimal_interval, @maximum_elapsed_time = interval.first, interval.last
+    else
+      @minimal_interval, @maximum_elapsed_time = interval, maximum_elapsed_time
+    end
+    raise ArgumentError, "Invalid range specified" if [@minimal_interval, @maximum_elapsed_time].any? { |i| !i.is_a?(Numeric) }
+
     @randomize_factor = 0
     @multiplier = 2.0
     clear

--- a/test/exponential_backoff_test.rb
+++ b/test/exponential_backoff_test.rb
@@ -2,6 +2,22 @@ require 'test/unit'
 require 'exponential_backoff'
 
 class ExponentialBackoffTest < Test::Unit::TestCase
+  def test_range_initializer
+    backoff = ExponentialBackoff.new(1..5)
+    assert_equal [1, 2, 4, 5], backoff.intervals_for(0..3)
+  end
+
+  def test_array_initializer
+    backoff = ExponentialBackoff.new([1, 5])
+    assert_equal [1, 2, 4, 5], backoff.intervals_for(0..3)
+  end
+
+  def test_no_maximal_time
+    assert_raise ArgumentError do
+      backoff = ExponentialBackoff.new(2)
+    end
+  end
+
   def test_multiplier_default
     min, max = 1, 2
     backoff = ExponentialBackoff.new(min, max)


### PR DESCRIPTION
Allow for backoff objects to be created using a range:

ExponentialBackoff.new(1..5)

or an array:

ExponentialBackoff.new([1, 5])
