### PR TITLE
Update to conform to bundler expectations for allowing gem autoloading by bundler

### DIFF
--- a/lib/exponential/backoff.rb
+++ b/lib/exponential/backoff.rb
@@ -1,0 +1,1 @@
+require 'exponential_backoff'

--- a/lib/exponential_backoff/version.rb
+++ b/lib/exponential_backoff/version.rb
@@ -1,3 +1,3 @@
 class ExponentialBackoff
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
Also, bump version.

Greetings,

Thanks for the slick gem.

I went to use `exponential-backoff` in a Ruby-on-Rails application and was surprised when `bundler` didn't autoload it.  I realized the issue was that the gem name is `exponential-backoff` so the `bundler` autoloader tries to load `lib/exponential/backoff.rb`.  I simply added that file and made it reference `exponential_backoff.rb` which allows `bundler` to successfully autoload.
