### PR TITLE
Add github action to test on current ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2' ]
+
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run tests
+        run: bundle exec rake

--- a/test/exponential_backoff_test.rb
+++ b/test/exponential_backoff_test.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 require 'minitest/autorun'
 require 'mutant/minitest/coverage'
 require 'exponential_backoff'


### PR DESCRIPTION
Heya - thanks for making this gem :-) I was about to implement my own exponential backoff mechanism at work and then discovered it. Wanted to make sure it'd fit us for the long term so I set up a fork to test against newer rubies using github-actions. Figured I'd contribute it back just so anyone coming to your repo has good confidence that it works on newer rubies.

For some reason ruby 3.3 and jruby were failing to install the gems in github-actions, so I haven't included them in the workflow. When testing locally they worked fine though - don't know the cause.

The "set" library seems to need explicitly requiring these days, too, so I've done that in the test file - though I know really it ought be done inside mutant-minitest.